### PR TITLE
Use 'allsorts' instead of 'allsorts_no_std'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,9 @@ readme = "README.md"
 [dependencies]
 xmlparser = { version = "0.13.3", default-features = false }
 mmapio = { version = "0.9.1", default-features = false }
-allsorts_no_std = { version = "0.5.2", default-features = false }
 rayon = { version = "1.5.0", default-features = false }
+allsorts = "0.12.1"
 
 [features]
 default = ["std"]
-std = ["allsorts_no_std/std"]
+std = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@
 
 extern crate xmlparser;
 extern crate mmapio;
-extern crate allsorts_no_std;
+extern crate allsorts;
 
 extern crate core;
 extern crate alloc;
@@ -372,7 +372,7 @@ fn FcParseFontFiles(files_to_parse: &[PathBuf])-> Vec<(FcPattern, FcFontPath)> {
 #[cfg(feature = "std")]
 fn FcParseFont(filepath: &PathBuf)-> Option<Vec<(FcPattern, FcFontPath)>> {
 
-    use allsorts_no_std::{
+    use allsorts::{
         tag,
         binary::read::ReadScope,
         font_data::FontData,
@@ -421,12 +421,12 @@ fn FcParseFont(filepath: &PathBuf)-> Option<Vec<(FcPattern, FcFontPath)>> {
         } else if name_id == FONT_SPECIFIER_NAME_ID {
             let family = f_family.as_ref()?;
             let name = fontcode_get_name(&name_data, FONT_SPECIFIER_NAME_ID).ok()??;
-            if name.is_empty() {
+            if name.to_bytes().is_empty() {
                 None
             } else {
                 Some((FcPattern {
-                    name: Some(name),
-                    family: Some(family.clone()),
+                    name: Some(String::from_utf8_lossy(name.to_bytes()).to_string()),
+                    family: Some(String::from_utf8_lossy(family.as_bytes()).to_string()),
                     bold: if is_bold { PatternMatch::True } else { PatternMatch::False },
                     italic: if is_italic { PatternMatch::True } else { PatternMatch::False },
                     .. Default::default() // TODO!


### PR DESCRIPTION
The 'allsorts_no_std' fork is unmaintained. It was only used inside 'cfg(feature = 'std")', so the fact that 'allsorts' depends on libstd won't cause any changes for consumers of this library.