### PR TITLE
Fix MacOS search locations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,8 +122,8 @@ impl FcFontCache {
             let home_dir = std::env::var("HOME").unwrap_or(String::new());
             let font_dirs = vec![
                 (Some(home_dir.as_ref()), "Library/Fonts"),
-                (None, "System/Library/Fonts"),
-                (None, "Library/Fonts"),
+                (None, "/System/Library/Fonts"),
+                (None, "/Library/Fonts"),
             ];
             FcFontCache {
                 map: FcScanDirectoriesInner(&font_dirs)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,8 +119,14 @@ impl FcFontCache {
 
         #[cfg(target_os = "macos")]
         {
+            let home_dir = std::env::var("HOME").unwrap_or(String::new());
+            let font_dirs = vec![
+                (Some(home_dir.as_ref()), "Library/Fonts"),
+                (None, "System/Library/Fonts"),
+                (None, "Library/Fonts"),
+            ];
             FcFontCache {
-                map: FcScanSingleDirectoryRecursive(PathBuf::from("~/Library/Fonts"))
+                map: FcScanDirectoriesInner(&font_dirs)
                     .into_iter()
                     .collect(),
             }


### PR DESCRIPTION
Expand the default search locations to include system and other built-in fonts. Also, fix searching user-installed fonts by explicitly specifying the `HOME` env variable rather than `~`. 